### PR TITLE
Optimize book import speed

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,19 +3,22 @@ package main
 import (
 	"flag"
 	"fmt"
+	"time"
 	"path/filepath"
 	"strings"
 )
 
 func loadDirs(db *FlatDB, allowedDirs []string) {
+	start := time.Now()
 	for _, dir := range allowedDirs {
 		err := db.AddDirR(dir)
 		if err != nil {
-			fmt.Println("failed to add dir -", err)
 		}
 	}
+	elapsed := time.Since(start)
 	fmt.Println("dirs loaded")
 	fmt.Println("books", len(db.books))
+	fmt.Printf("Import took %s\n",elapsed)
 }
 
 func main() {
@@ -46,6 +49,7 @@ func main() {
 	db.Load()
 	// load all books recursively
 	fmt.Println("load all books recursively")
+	
 	go loadDirs(db, config.AllowedDirs)
 	fmt.Println("finished loading all books recursively")
 	svr := Server{

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func loadDirs(db *FlatDB, allowedDirs []string) {
 	for _, dir := range allowedDirs {
 		err := db.AddDirR(dir)
 		if err != nil {
+			fmt.Println("failed to add dir -", err)
 		}
 	}
 	elapsed := time.Since(start)

--- a/main.go
+++ b/main.go
@@ -3,19 +3,23 @@ package main
 import (
 	"flag"
 	"fmt"
+	"time"
 	"path/filepath"
 	"strings"
 )
 
 func loadDirs(db *FlatDB, allowedDirs []string) {
+	start := time.Now()
 	for _, dir := range allowedDirs {
 		err := db.AddDirR(dir)
 		if err != nil {
 			fmt.Println("failed to add dir -", err)
 		}
 	}
+	elapsed := time.Since(start)
 	fmt.Println("dirs loaded")
 	fmt.Println("books", len(db.books))
+	fmt.Printf("Import took %s\n",elapsed)
 }
 
 func main() {
@@ -46,6 +50,7 @@ func main() {
 	db.Load()
 	// load all books recursively
 	fmt.Println("load all books recursively")
+	
 	go loadDirs(db, config.AllowedDirs)
 	fmt.Println("finished loading all books recursively")
 	svr := Server{

--- a/server.go
+++ b/server.go
@@ -34,12 +34,10 @@ func (svr *Server) Start() {
 	//	fmt.Println("Error loading httpSession for previous sessions")
 	//	log.Fatal(err)
 	//}
-		fmt.Println("debug still going on")
 	h := http.NewServeMux()
 
 	// public folder access
 
-	// // debug with local files
 	// fserv := http.FileServer(http.Dir(svr.Config.PathDir + "/web"))
 	// fRead := ioutil.ReadFile
 


### PR DESCRIPTION
**Optimize book import speed**

Tested import of 914 books on a Raspberry Pi 4.
Before optimizations it took 43s, after optimizations it took 29s.

Changed code to use the golang built in csv functions instead of manually performing the csv book import with file and string operations.